### PR TITLE
Fix broken link to GitHub's Safe Harbor Policy in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,4 +28,4 @@ This information will help us triage your report more quickly.
 
 ## Policy
 
-See [GitHub's Safe Harbor Policy](https://docs.github.com/en/github/site-policy/github-bug-bounty-program-legal-safe-harbor#1-safe-harbor-terms)
+See [GitHub's Safe Harbor Policy](https://docs.github.com/en/site-policy/security-policies/github-bug-bounty-program-legal-safe-harbor#1-safe-harbor-terms)


### PR DESCRIPTION
### Why:

Link to GitHub's Safe Harbor Policy at the bottom of SECURITY.md was broken and pointed to a non-existent page.

### What's being changed:

Update link in SECURITY.md to point to GitHub's Safe Harbor Policy.

### Check off the following:

- [ ] ~~For workflow changes, I have verified the Actions workflows function as expected.~~
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
